### PR TITLE
Break out Bech32 util functions into their own class

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol
 
 import org.bitcoins.core.gen.{ AddressGenerator, ChainParamsGenerator, ScriptGenerators }
-import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.util.{ Bech32, BitcoinSLogger }
 import org.scalacheck.{ Gen, Prop, Properties }
 
 import scala.annotation.tailrec
@@ -47,7 +47,7 @@ class Bech32Spec extends Properties("Bech32Spec") {
   @tailrec
   private def pickReplacementChar(oldChar: Char): Char = {
     val rand = Math.abs(Random.nextInt)
-    val newChar = Bech32Address.charset(rand % Bech32Address.charset.size)
+    val newChar = Bech32.charset(rand % Bech32.charset.size)
     //make sure we don't pick the same char we are replacing in the bech32 address
     if (oldChar == newChar) pickReplacementChar(oldChar)
     else newChar

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.config.{ MainNet, TestNet3 }
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.number.UInt8
 import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.util.Bech32
 import org.scalatest.{ FlatSpec, MustMatchers }
 
 import scala.util.{ Success, Try }
@@ -74,38 +75,38 @@ class Bech32Test extends FlatSpec with MustMatchers {
   }
 
   it must "encode 0 byte correctly" in {
-    val addr = Bech32Address(bc, Seq(UInt8.zero))
+    val addr = Bech32Address(bc, Vector(UInt8.zero))
     addr.value must be("bc1q9zpgru")
   }
 
   it must "create the correct checksum for a 0 byte address" in {
-    val checksum = Bech32Address.createChecksum(bc, Seq(UInt8.zero))
+    val checksum = Bech32Address.createChecksum(bc, Vector(UInt8.zero))
     checksum must be(Seq(5, 2, 1, 8, 3, 28).map(i => UInt8(i.toShort)))
-    checksum.map(ch => Bech32Address.charset(ch.toInt)).mkString must be("9zpgru")
+    checksum.map(ch => Bech32.charset(ch.toInt)).mkString must be("9zpgru")
   }
 
   it must "encode base 8 to base 5" in {
     val z = UInt8.zero
-    val encoded = Bech32Address.encode(Seq(z))
-    encoded.map(Bech32Address.encodeToString(_)) must be(Success("qq"))
+    val encoded = Bech32.from8bitTo5bit(Vector(z))
+    encoded.map(Bech32.encodeToString(_)) must be(Success("qq"))
 
-    val encoded1 = Bech32Address.encode(Seq(z, UInt8.one))
+    val encoded1 = Bech32.from8bitTo5bit(Vector(z, UInt8.one))
     encoded1 must be(Success(Seq(z, z, z, UInt8(16.toShort))))
     //130.toByte == -126
-    val encoded2 = Bech32Address.encode(Seq(130).map(i => UInt8(i.toShort)))
+    val encoded2 = Bech32.from8bitTo5bit(Vector(130).map(i => UInt8(i.toShort)))
     encoded2 must be(Success(Seq(16, 8).map(i => UInt8(i.toShort))))
 
     //130.toByte == -126
-    val encoded3 = Bech32Address.encode(Seq(255, 255).map(i => UInt8(i.toShort)))
+    val encoded3 = Bech32.from8bitTo5bit(Vector(255, 255).map(i => UInt8(i.toShort)))
     encoded3 must be(Success(Seq(31, 31, 31, 16).map(i => UInt8(i.toShort))))
 
-    val encoded4 = Bech32Address.encode(Seq(255, 255, 255, 255).map(i => UInt8(i.toShort)))
+    val encoded4 = Bech32.from8bitTo5bit(Vector(255, 255, 255, 255).map(i => UInt8(i.toShort)))
     encoded4 must be(Success(Seq(31, 31, 31, 31, 31, 31, 24).map(i => UInt8(i.toShort))))
 
-    val encoded5 = Bech32Address.encode(Seq(255, 255, 255, 255, 255).map(i => UInt8(i.toShort)))
+    val encoded5 = Bech32.from8bitTo5bit(Vector(255, 255, 255, 255, 255).map(i => UInt8(i.toShort)))
     encoded5 must be(Success(Seq(31, 31, 31, 31, 31, 31, 31, 31).map(i => UInt8(i.toShort))))
 
-    val encoded6 = Bech32Address.encode(Seq(255, 255, 255, 255, 255, 255).map(i => UInt8(i.toShort)))
+    val encoded6 = Bech32.from8bitTo5bit(Vector(255, 255, 255, 255, 255, 255).map(i => UInt8(i.toShort)))
     encoded6 must be(Success(Seq(31, 31, 31, 31, 31, 31, 31, 31, 31, 28).map(i => UInt8(i.toShort))))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
@@ -32,7 +32,7 @@ class NumberUtilSpec extends Properties("NumberUtilSpec") {
         //but the trick is we need to make sure that the u8s generated are valid numbers in the 'from' base
         val u32From = UInt32(8.toShort)
         val u32To = UInt32(to.toShort)
-        val converted = NumberUtil.convertUInt8s(u8s, u32From, u32To, true)
+        val converted = NumberUtil.convertUInt8s(u8s.toVector, u32From, u32To, true)
         val original = converted.flatMap(c => NumberUtil.convertUInt8s(c, u32To, u32From, false))
         if (original.isFailure) {
           throw original.failed.get

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -200,8 +200,8 @@ object UInt8 extends Factory[UInt8] with BaseNumbers[UInt8] {
     ByteVector(us.map(toByte(_)))
   }
 
-  def toUInt8s(bytes: ByteVector): Seq[UInt8] = {
-    bytes.toSeq.map { b: Byte => toUInt8(b) }
+  def toUInt8s(bytes: ByteVector): Vector[UInt8] = {
+    bytes.toArray.map(toUInt8(_)).toVector
   }
 
   def checkBounds(res: BigInt): UInt8 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.util._
 
 sealed abstract class LnInvoice {
-  val bech32Separator: Char = Bech32Address.separator
+  val bech32Separator: Char = Bech32.separator
 
   def hrp: LnHumanReadablePart
 
@@ -24,29 +24,39 @@ sealed abstract class LnInvoice {
   def bech32Checksum: String = "" //TODO: Unimplemented. See Bech32Address.createChecksum
 
   //TODO: Refactor Into Bech32Address?
-  def uInt64ToBase32(input: UInt64): Seq[UInt8] = {
+  def uInt64ToBase32(input: UInt64): Vector[UInt8] = {
     //To fit a UInt64 value, we need at most ceil(64 / 5) = 13 groups of 5 bits.
     val arr: Array[Int] = new Array[Int](13)
     for (x <- 0 to 12) {
       arr(x) = (input >> x * 5 & UInt64(0x1F)).toInt.toByte
     }
-    arr.reverse.dropWhile(_ == 0).map(b => UInt8(b))
+    arr.reverse.dropWhile(_ == 0).map(b => UInt8(b)).toVector
   }
 
-  def hexToBase32(hex: String): Seq[UInt8] = {
-    val byteArray = BitcoinSUtil.decodeHex(hex).toSeq.map(b => UInt8(b))
-    Bech32Address.encode(byteArray).get
+  private def hexToBase32(hex: String): Vector[UInt8] = {
+    val byteArray = BitcoinSUtil.decodeHex(hex)
+    Bech32.from8bitTo5bit(byteArray).get
   }
 
-  def bech32TimeStamp: String = Bech32Address.encodeToString(uInt64ToBase32(timestamp))
+  private def bech32TimeStamp: String = Bech32.encodeToString(uInt64ToBase32(timestamp))
 
-  def bech32Signature: String = {
+  private def bech32Signature: String = {
     val signatureHex = signature._1.hex + "%02d".format(signature._2) //Append version information
     val signatureBase32 = hexToBase32(signatureHex)
-    Bech32Address.encodeToString(signatureBase32)
+    Bech32.encodeToString(signatureBase32)
   }
 
-  override def toString: String = { hrp.toString + bech32Separator + bech32TimeStamp + lnTags.toString + bech32Signature + bech32Checksum }
+  override def toString: String = {
+    val b = new StringBuilder
+    b.append(hrp.toString)
+    b.append(bech32Separator)
+    b.append(bech32TimeStamp)
+    b.append(lnTags.toString)
+    b.append(bech32Signature)
+    b.append(bech32Checksum)
+
+    b.toString()
+  }
 }
 
 case class Invoice(hrp: LnHumanReadablePart, timestamp: UInt64, lnTags: LnInvoiceTags,

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -1,0 +1,135 @@
+package org.bitcoins.core.util
+
+import org.bitcoins.core.number.{ UInt32, UInt8 }
+import scodec.bits.ByteVector
+
+import scala.annotation.tailrec
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * A abstract class representing basic utility functions of Bech32
+ * For more information on Bech32 please seee BIP173
+ * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki]]
+ */
+sealed abstract class Bech32 {
+
+  /** Separator used to separate the hrp & data parts of a bech32 addr */
+  val separator = '1'
+
+  /** https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32 */
+  val charset: Vector[Char] = Vector('q', 'p', 'z', 'r', 'y', '9', 'x', '8',
+    'g', 'f', '2', 't', 'v', 'd', 'w', '0',
+    's', '3', 'j', 'n', '5', '4', 'k', 'h',
+    'c', 'e', '6', 'm', 'u', 'a', '7', 'l')
+
+  private val generators: Vector[Long] = Vector(
+    UInt32("3b6a57b2").toLong,
+    UInt32("26508e6d").toLong, UInt32("1ea119fa").toLong,
+    UInt32("3d4233dd").toLong, UInt32("2a1462b3").toLong)
+
+  private val u32Five = UInt32(5)
+  private val u32Eight = UInt32(8)
+
+  /**
+   * Creates a checksum for the given byte vector according to BIP173
+   * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32]]
+   * @param bytes
+   * @return
+   */
+  def createChecksum(bytes: Vector[UInt8]): Vector[UInt8] = {
+    val z = UInt8.zero
+    val polymod: Long = polyMod(bytes ++ Array(z, z, z, z, z, z)) ^ 1
+    //[(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+
+    val result: Vector[UInt8] = 0.until(6).map { i =>
+      //((polymod >> five * (five - u)) & UInt8(31.toShort))
+      UInt8(((polymod >> 5 * (5 - i)) & 31).toShort)
+    }.toVector
+    result
+  }
+
+  /**
+   * Expands the human readable part of a bech32 address as per BIP173
+   * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32]]
+   * @param bytes
+   * @return
+   */
+  def hrpExpand(bytes: ByteVector): Vector[UInt8] = {
+    val x: ByteVector = bytes.map { b: Byte =>
+      (b >> 5).toByte
+    }
+    val withZero: ByteVector = x ++ ByteVector.low(1)
+
+    val y: ByteVector = bytes.map { char =>
+      (char & 0x1f).toByte
+    }
+    val result = UInt8.toUInt8s(withZero ++ y)
+    result
+  }
+
+  def polyMod(bytes: Seq[UInt8]): Long = {
+    var chk: Long = 1
+    bytes.map { v =>
+      val b = chk >> 25
+      //chk = (chk & 0x1ffffff) << 5 ^ v
+      chk = (chk & 0x1ffffff) << 5 ^ v.toLong
+      0.until(5).map { i: Int =>
+        //chk ^= GEN[i] if ((b >> i) & 1) else 0
+        if (((b >> i) & 1) == 1) {
+          chk = chk ^ generators(i)
+        }
+      }
+    }
+    chk
+  }
+
+  /**
+   * Takes in the data portion of a bech32 address and decodes it to a byte array
+   * It also checks the validity of the data portion according to BIP173
+   */
+  def checkDataValidity(data: String): Try[ByteVector] = {
+    @tailrec
+    def loop(remaining: List[Char], accum: ByteVector, hasUpper: Boolean, hasLower: Boolean): Try[ByteVector] = remaining match {
+      case Nil => Success(accum.reverse)
+      case h :: t =>
+        if (!charset.contains(h.toLower)) {
+          Failure(new IllegalArgumentException("Invalid character in data of bech32 address, got: " + h))
+        } else {
+          if ((h.isUpper && hasLower) || (h.isLower && hasUpper)) {
+            Failure(new IllegalArgumentException("Cannot have mixed case for bech32 address"))
+          } else {
+            val byte = charset.indexOf(h.toLower).toByte
+            require(byte >= 0 && byte < 32, "Not in valid range, got: " + byte)
+            loop(t, byte +: accum, h.isUpper || hasUpper, h.isLower || hasLower)
+          }
+        }
+    }
+    val payload: Try[ByteVector] = loop(data.toCharArray.toList, ByteVector.empty,
+      false, false)
+    payload
+  }
+
+  /** Takes a base32 byte array and encodes it to a string */
+  def encodeToString(b: Vector[UInt8]): String = {
+    b.map(b => charset(b.toInt)).mkString
+  }
+
+  /** Converts a byte vector from base 8 to base 5 */
+  def from8bitTo5bit(bytes: ByteVector): Try[Vector[UInt8]] = {
+    val u8s = UInt8.toUInt8s(bytes)
+    from8bitTo5bit(u8s)
+  }
+
+  /** Converts a byte array from base 8 to base 5 */
+  def from8bitTo5bit(bytes: Vector[UInt8]): Try[Vector[UInt8]] = {
+    NumberUtil.convertUInt8s(bytes, u32Eight, u32Five, true)
+  }
+
+  /** Decodes a byte array from base 5 to base 8 */
+  def from5bitTo8bit(b: Vector[UInt8]): Try[Vector[UInt8]] = {
+    NumberUtil.convertUInt8s(b, u32Five, u32Eight, false)
+  }
+
+}
+
+object Bech32 extends Bech32

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -66,10 +66,10 @@ trait NumberUtil extends BitcoinSLogger {
   def toLong(hex: String): Long = toLong(BitcoinSUtil.decodeHex(hex))
 
   /** Converts a sequence uint8 'from' base to 'to' base */
-  def convertUInt8s(data: Seq[UInt8], from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
+  def convertUInt8s(data: Vector[UInt8], from: UInt32, to: UInt32, pad: Boolean): Try[Vector[UInt8]] = {
     var acc: UInt32 = UInt32.zero
     var bits: UInt32 = UInt32.zero
-    var ret: Seq[UInt8] = Nil
+    var ret: Vector[UInt8] = Vector.empty
     val maxv: UInt32 = (UInt32.one << to) - UInt32.one
     val eight = UInt32(8)
     if (from > eight || to > eight) {
@@ -83,7 +83,7 @@ trait NumberUtil extends BitcoinSLogger {
           bits = bits + from
           while (bits >= to) {
             bits = bits - to
-            val r: Seq[UInt8] = Seq(UInt8((((acc >> bits) & maxv).toInt.toShort)))
+            val r: Vector[UInt8] = Vector(UInt8((((acc >> bits) & maxv).toInt.toShort)))
             ret = ret ++ r
           }
         }
@@ -101,7 +101,7 @@ trait NumberUtil extends BitcoinSLogger {
     }
   }
 
-  def convertBytes(data: ByteVector, from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
+  def convertBytes(data: ByteVector, from: UInt32, to: UInt32, pad: Boolean): Try[Vector[UInt8]] = {
     convertUInt8s(UInt8.toUInt8s(data), from, to, pad)
   }
 }


### PR DESCRIPTION
This PR breaks out Bech32 specific fucntionality into it's own class. This gets away from all this bech32 being embedded directly in `Bech32Address`. This creates a logical distinction between the actaul Bech32 encoding and the `Bech32Address` used for blockchain protocols. Now it is easier to re-use the actual encoding logic for things like Lightning Network Invoices